### PR TITLE
fix window size when scaling is enabled

### DIFF
--- a/src/main/java/xyz/duncanruns/eyesee/EyeSeeGUI.java
+++ b/src/main/java/xyz/duncanruns/eyesee/EyeSeeGUI.java
@@ -10,6 +10,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
+import java.awt.geom.AffineTransform;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -42,7 +43,11 @@ public class EyeSeeGUI extends JFrame implements WindowListener {
         setLocation(options.x, options.y);
         addWindowListener(this);
         setResizable(false);
-        setSize(options.displayWidth(), options.displayHeight());
+        // make the window size the same units StretchBlt uses (physical pixels)
+        AffineTransform transform = getGraphicsConfiguration().getDefaultTransform();
+        double scaleX = transform.getScaleX();
+        double scaleY = transform.getScaleY();
+        setSize((int)(options.displayWidth()/scaleX), (int)(options.displayHeight()/scaleY));
         setAlwaysOnTop(true);
         String randTitle = "EyeSee " + new Random().nextInt();
         setTitle(randTitle);


### PR DESCRIPTION
previously, when the scale factor of the display was not 1, the size of the window would be too big as the os would scale the window but StretchBlt uses physical pixels so only part of the window would be used anyway, this scales the window back down so the scaleFactor is correct and the operating system scaling is not applied

before:
![before](https://github.com/DuncanRuns/EyeSee/assets/45241413/0b11d0f5-78f8-4067-9b4c-5229730e1d5e)

after:
![after](https://github.com/DuncanRuns/EyeSee/assets/45241413/c10be002-55c1-4604-b05f-11ff5bcaf57d)
